### PR TITLE
Fix bilinear transformations

### DIFF
--- a/frontend/Einsum_explanation.ml
+++ b/frontend/Einsum_explanation.ml
@@ -1048,7 +1048,7 @@ let tutorial container =
             El.li [ example "i, j -> i j"; txt' " (outer product)" ];
             El.li
               [
-                example "i j, j k l -> i j";
+                example "i k, j k l, i l -> i j";
                 txt' " (bilinear transformation, see ";
                 a "https://rockt.ai/2018/04/30/einsum" "Tim Rocktäschel's post";
                 txt' ")";


### PR DESCRIPTION
Bilinear forms always operate on 3 arguments.
Depending on the shape of the inputs, the "EinSum" definition will be different, but Tim Rocktaschel's post does it this way:

```
i k, j k l, i l, -> i j
```

PS: Thanks for a nice visualization, @joelburget! Saw it on HackerNews today 🤗 